### PR TITLE
[FIX]rollback vdev config for container

### DIFF
--- a/internal/pkg/dcu/server.go
+++ b/internal/pkg/dcu/server.go
@@ -381,7 +381,7 @@ func (p *Plugin) createvdevFiles(current *corev1.Pod, ctr *corev1.Container, req
 	}
 	dirName := string(current.UID) + "_" + ctr.Name + "_" + fmt.Sprint(devidx) + "_" + fmt.Sprint(pipeid) + "_" + fmt.Sprint(vdevidx) + "_" + fmt.Sprint(coremsk1) + "_" + fmt.Sprint(coremsk2)
 	cacheFileHostDirectory := fmt.Sprintf("/usr/local/vgpu/dcu/%s", dirName)
-	err = createvdevFile(pcibusId, coremsk1, coremsk2, reqcores, mem, devidx, vdevidx, pipeid, cacheFileHostDirectory, fmt.Sprintf("vdev%d.conf", vdevidx))
+	err = createvdevFile(pcibusId, coremsk1, coremsk2, reqcores, mem, 0, vdevidx, pipeid, cacheFileHostDirectory, "vdev0.conf")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
this commit  https://github.com/Project-HAMi/dcu-vgpu-device-plugin/commit/ca474a84475f79e8bda5f4279001db1e8ed7ad7b#diff-5f1987bb4cb78beeb0a3a8e29dce4e473add246f860dd74eb83a28b8414dbbf8R381

change the vdev.conf device_id from 0 to host dcu deviceID.
don't know why here is hard code to 0.

but we found that when a node contains 1+ dcu, it will mount total dcu to container instead of a vdev when container bind to the 2nd device.

anyway, rollback to hard coded `0` for `device_id` could work