### PR TITLE
use device serial number to construct id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,29 @@
 # Copyright 2018 Advanced Micro Devices, Inc.  All rights reserved.
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #      http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 FROM golang:1.23-bullseye AS GOBUILD
-ADD . /device-plugin
-# ARG GOPROXY=https://goproxy.cn,direct
 RUN apt-get update && apt-get -y install libhwloc-dev libdrm-dev
-RUN cd /device-plugin && go build -o ./k8s-device-plugin cmd/k8s-device-plugin/main.go
+WORKDIR /device-plugin
+COPY dcu-dcgm ./dcu-dcgm
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd ./cmd
+COPY internal ./internal
+RUN go build -o ./k8s-device-plugin cmd/k8s-device-plugin/main.go
 
 FROM ubuntu:20.04
 ENV TZ=Asia/Dubai
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >/etc/timezone
 RUN apt-get update && apt-get -y install libhwloc-dev libdrm-dev pciutils libelf-dev kmod
 ENV LD_LIBRARY_PATH=/opt/hygondriver/hip/lib:/opt/hygondriver/llvm/lib:/opt/hygondriver/lib:/opt/hygondriver/lib64:/opt/hyhal/lib:/opt/hyhal/lib64:/opt/hygondriver/.hyhal/lib:/opt/hygondriver/.hyhal/lib64:
 ENV PATH=/opt/hygondriver/bin:/opt/hygondriver/llvm/bin:/opt/hygondriver/hip/bin:/opt/hygondriver/hip/bin/hipify:/opt/hyhal/bin:/opt/hygondriver/.hyhal/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -31,6 +31,7 @@ import (
 	"github.com/HAMi/dcu-vgpu-device-plugin/internal/pkg/api"
 	"github.com/HAMi/dcu-vgpu-device-plugin/internal/pkg/util/client"
 	"github.com/Project-HAMi/HAMi/pkg/util/nodelock"
+	"github.com/Project-HAMi/dcu-dcgm/pkg/dcgm"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -472,4 +473,28 @@ func ListDcuDrmDevices() ([]string, []string, error) {
 	}
 
 	return dcuDrms, dcuRenders, nil
+}
+
+func GetDeviceSerialInfos(deviceInfos []dcgm.DeviceInfo) ([]dcgm.DeviceSerialInfo, error) {
+	dvIdList := make([]int, len(deviceInfos))
+
+	for i, info := range deviceInfos {
+		dvIdList[i] = info.DvInd
+	}
+
+	return dcgm.ShowSerialNumber(dvIdList)
+}
+
+func GetSerialNumberToDvIdMap(deviceInfos []dcgm.DeviceInfo) (map[string]int, error) {
+	deviceSerialInfos, err := GetDeviceSerialInfos(deviceInfos)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get device serial numbers: %w", err)
+	}
+
+	serialNumberToDvId := make(map[string]int)
+	for _, info := range deviceSerialInfos {
+		serialNumberToDvId[info.SerialNumber] = info.DeviceID
+	}
+
+	return serialNumberToDvId, nil
 }


### PR DESCRIPTION
fix #16 

The device id in the device information reported and registered to the node by the current dcu-vgpu-device-plugin is constructed by adding the device index to the DCU- prefix.

If there is only one DCU node in the cluster, there is no effect on HAMi scheduling. However, if there are multiple DCU nodes in the cluster, the scheduler will not be able to schedule properly, for example, use use-uuid to limit the scheduling range.

The dcu-vgpu device plugin originally integrates dcgm to get device information. At the same time, dcgm provides a `ShowSerialNumber` function to get the serial number of the device based on the specified device index. Usage:

```go
deviceSerialInfos, err := dcgm.ShowUId([]int{0, 1, 2, 3, 4, 5, 6, 7})
```

根据查询出来的序列号构造出设备 id，格式为 `DCU-<serial number>`。影响范围包括如下两点
1. 设备插件注册到节点上的 Annotation，以及
2. 为容器分配设备时需要根据序列号反向找回对应的设备序号，以挂载正确的设备文件

测试结果如下：

根据日志时间戳，调用 `dcgm.ShowSerialNumber` 的时间不超过 1s，时间开销少。
<img width="933" height="387" alt="Pasted image 20250717194850" src="https://github.com/user-attachments/assets/080ad376-0223-4e74-a724-a9750816bf7c" />

节点 Annotation 如下：
<img width="942" height="343" alt="Pasted image 20250717195124" src="https://github.com/user-attachments/assets/233d9282-e4ea-43f7-82dd-56d84320be07" />

在一个 8 卡集群中申请 0~3 号这 4 张卡，调度成功的 Pod Annotation 如下：
<img width="1241" height="286" alt="image" src="https://github.com/user-attachments/assets/13b14ef0-9026-4bf0-986a-c5c523e5f646" />

容器内部实际挂载设备：
<img width="526" height="34" alt="Pasted image 20250717205239" src="https://github.com/user-attachments/assets/5e08e84c-43f0-4fef-ad60-6711f99186f4" />

结论：可以在不修改调度器的情况下正常调度，并且可以正常使用根据 uuid 指定调度范围的特性。
