### PR TITLE
fix(create vdevfile with new format device uuid):

### DIFF
--- a/internal/pkg/dcu/register.go
+++ b/internal/pkg/dcu/register.go
@@ -43,7 +43,7 @@ func (r *Plugin) apiDevices() (*[]*api.DeviceInfo, error) {
 		if val.MemoryTotal > 0 {
 			res = append(res, &api.DeviceInfo{
 				Index:   val.DvInd,
-				Id:      "DCU-" + fmt.Sprint(deviceSerialInfos[idx].SerialNumber),
+				Id:      util.GetDeviceUUIDFromDevSerialNumber(deviceSerialInfos[idx].SerialNumber),
 				Count:   4,
 				Devmem:  int32(val.MemoryTotal / 1024 / 1024),
 				Devcore: 100,

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -498,3 +498,11 @@ func GetSerialNumberToDvIdMap(deviceInfos []dcgm.DeviceInfo) (map[string]int, er
 
 	return serialNumberToDvId, nil
 }
+
+func GetDeviceUUIDFromDevSerialNumber(devSerialNumber string) string {
+	return fmt.Sprintf("DCU-%s", devSerialNumber)
+}
+
+func GetDevSerialNumberFromDeviceUUID(uuid string, devSerialNumber *string) (int, error) {
+	return fmt.Sscanf(uuid, "DCU-%s", devSerialNumber)
+}


### PR DESCRIPTION
In the previous PR #17, the serial numbers of physical devices were used to build the new version of the UUID, but a change to the Plugin's `createvdevFiles` function was missed.

This PR Fixed the function ` createvdevFiles` still use function `getIndexFromUUID` to extracts the physical device index from the old version of the UUID, migrated the implementation to extract the serial number from the new version of the UUID and further obtain the device serial number.

